### PR TITLE
AWS Secrets Managerに設定するキー名がsendgridとslackで逆になっていたので修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http://nopipi.hatenablog.com/entry/2019/01/03/132701
 
 ```json
 {
-  "TOKEN": "中身は文字列なら何でもOK"
+  "API_KEY": "中身は文字列なら何でもOK"
 }
 ```
 
@@ -86,7 +86,7 @@ http://nopipi.hatenablog.com/entry/2019/01/03/132701
 
 ```json
 {
-  "API_KEY": "中身は文字列なら何でもOK"
+  "TOKEN": "中身は文字列なら何でもOK"
 }
 ```
 


### PR DESCRIPTION
# 修正内容
表題の通りです。