### PR TITLE
CognitoUserPoolを追加

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -1,0 +1,52 @@
+resource "aws_cognito_user_pool" "pool" {
+  name                     = "${terraform.workspace}-keitakn"
+  auto_verified_attributes = ["email"]
+
+  admin_create_user_config {
+    allow_admin_create_user_only = false
+  }
+
+  password_policy {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 7
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_message        = "検証コードは {####} です。"
+    email_subject        = "検証コード"
+    sms_message          = "検証コードは {####} です。"
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "email"
+    required                 = true
+
+    string_attribute_constraints {
+      min_length = 0
+      max_length = 2048
+    }
+  }
+
+  email_configuration {
+    source_arn            = var.ses["email_identity_arn"]
+    email_sending_account = "DEVELOPER"
+  }
+}
+
+// https://github.com/keitakn/next-idaas
+resource "aws_cognito_user_pool_client" "next_idaas_client" {
+  name                          = "${terraform.workspace}-next-idaas"
+  user_pool_id                  = aws_cognito_user_pool.pool.id
+  generate_secret               = false
+  prevent_user_existence_errors = "ENABLED"
+  refresh_token_validity        = 30
+  explicit_auth_flows           = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+}

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -1,5 +1,5 @@
-resource "aws_cognito_user_pool" "pool" {
-  name                     = "${terraform.workspace}-keitakn"
+resource "aws_cognito_user_pool" "user_pool" {
+  name                     = "${terraform.workspace}-keitakn-user-pool"
   auto_verified_attributes = ["email"]
 
   admin_create_user_config {
@@ -49,12 +49,75 @@ resource "aws_cognito_user_pool" "pool" {
   }
 }
 
+resource "aws_cognito_identity_pool" "id_pool" {
+  identity_pool_name               = "${terraform.workspace} keitakn IDPool"
+  allow_unauthenticated_identities = false
+}
+
+resource "aws_iam_role" "authenticated" {
+  name = "${terraform.workspace}-cognito-authenticated"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "cognito-identity.amazonaws.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "cognito-identity.amazonaws.com:aud": "${aws_cognito_identity_pool.id_pool.id}"
+        },
+        "ForAnyValue:StringLike": {
+          "cognito-identity.amazonaws.com:amr": "authenticated"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "authenticated" {
+  name = "${terraform.workspace}-authenticated-policy"
+  role = aws_iam_role.authenticated.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "mobileanalytics:PutEvents",
+        "cognito-sync:*",
+        "cognito-identity:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cognito_identity_pool_roles_attachment" "id_pool" {
+  identity_pool_id = aws_cognito_identity_pool.id_pool.id
+
+  roles = {
+    "authenticated" = aws_iam_role.authenticated.arn
+  }
+}
+
 // https://github.com/keitakn/next-idaas
 resource "aws_cognito_user_pool_client" "next_idaas_client" {
   name                          = "${terraform.workspace}-next-idaas"
-  user_pool_id                  = aws_cognito_user_pool.pool.id
+  user_pool_id                  = aws_cognito_user_pool.user_pool.id
   generate_secret               = false
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
-  explicit_auth_flows           = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
 }

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -6,6 +6,8 @@ resource "aws_cognito_user_pool" "pool" {
     allow_admin_create_user_only = false
   }
 
+  username_attributes = ["email", "phone_number"]
+
   password_policy {
     minimum_length                   = 8
     require_lowercase                = true
@@ -13,6 +15,12 @@ resource "aws_cognito_user_pool" "pool" {
     require_symbols                  = true
     require_uppercase                = true
     temporary_password_validity_days = 7
+  }
+
+  mfa_configuration = "OPTIONAL"
+
+  software_token_mfa_configuration {
+    enabled = true
   }
 
   verification_message_template {

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -119,8 +119,8 @@ resource "aws_cognito_identity_pool_roles_attachment" "id_pool" {
 }
 
 // https://github.com/keitakn/next-idaas
-resource "aws_cognito_user_pool_client" "next_idaas_client" {
-  name                          = "${terraform.workspace}-next-idaas"
+resource "aws_cognito_user_pool_client" "next_idaas_spa_client" {
+  name                          = "${terraform.workspace}-next-idaas-spa"
   user_pool_id                  = aws_cognito_user_pool.user_pool.id
   generate_secret               = false
   prevent_user_existence_errors = "ENABLED"

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -49,6 +49,11 @@ resource "aws_cognito_user_pool" "user_pool" {
   }
 }
 
+resource "aws_cognito_user_pool_domain" "admin_user_nurse_senka" {
+  domain       = "${terraform.workspace}-keitakn"
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+}
+
 resource "aws_cognito_identity_pool" "id_pool" {
   identity_pool_name               = "${terraform.workspace} keitakn IDPool"
   allow_unauthenticated_identities = false

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -24,10 +24,10 @@ resource "aws_cognito_user_pool" "user_pool" {
   }
 
   verification_message_template {
-    default_email_option = "CONFIRM_WITH_CODE"
-    email_message        = "検証コードは {####} です。"
-    email_subject        = "検証コード"
-    sms_message          = "検証コードは {####} です。"
+    default_email_option  = "CONFIRM_WITH_LINK"
+    email_message_by_link = "メールアドレスを検証するには、次のリンクをクリックしてください。 {##Verify Email##}"
+    email_subject_by_link = "cognito 検証リンク"
+    sms_message           = "検証コードは {####} です。"
   }
 
   schema {

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -125,4 +125,19 @@ resource "aws_cognito_user_pool_client" "next_idaas_spa_client" {
   generate_secret               = false
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
+
+  supported_identity_providers = ["COGNITO"]
+
+  callback_urls = sort([
+    "http://localhost:3900/cognito/authorized",
+  ])
+
+  logout_urls = sort([
+    "http://localhost:3900/cognito/logout",
+  ])
+
+  allowed_oauth_flows_user_pool_client = true
+
+  allowed_oauth_flows  = ["code"]
+  allowed_oauth_scopes = ["openid", "phone", "email", "profile"]
 }

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -24,10 +24,10 @@ resource "aws_cognito_user_pool" "user_pool" {
   }
 
   verification_message_template {
-    default_email_option  = "CONFIRM_WITH_LINK"
-    email_message_by_link = "メールアドレスを検証するには、次のリンクをクリックしてください。 {##Verify Email##}"
-    email_subject_by_link = "cognito 検証リンク"
-    sms_message           = "検証コードは {####} です。"
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_message        = "検証コードは {####} です。"
+    email_subject        = "検証コード"
+    sms_message          = "検証コードは {####} です。"
   }
 
   schema {

--- a/modules/aws/cognito/ssm.tf
+++ b/modules/aws/cognito/ssm.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret" "next_idaas" {
+  name = "${terraform.workspace}/next-idaas"
+}
+
+data "aws_secretsmanager_secret_version" "next_idaas" {
+  secret_id = data.aws_secretsmanager_secret.next_idaas.id
+}

--- a/modules/aws/cognito/variables.tf
+++ b/modules/aws/cognito/variables.tf
@@ -1,0 +1,5 @@
+variable "ses" {
+  type = map(string)
+
+  default = {}
+}

--- a/modules/aws/ses/main.tf
+++ b/modules/aws/ses/main.tf
@@ -1,0 +1,46 @@
+resource "aws_ses_domain_identity" "ses" {
+  domain = lookup(
+    var.public_domain,
+    "${terraform.workspace}.name",
+    var.public_domain["default.name"]
+  )
+}
+
+data "aws_route53_zone" "main" {
+  name = lookup(
+    var.public_domain,
+    "${terraform.workspace}.name",
+    var.public_domain["default.name"]
+  )
+}
+
+resource "aws_route53_record" "ses_txt_record" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_amazonses.${data.aws_route53_zone.main.name}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [
+    aws_ses_domain_identity.ses.verification_token
+  ]
+}
+
+resource "aws_ses_domain_dkim" "dkim" {
+  domain = lookup(
+    var.public_domain,
+    "${terraform.workspace}.name",
+    var.public_domain["default.name"]
+  )
+}
+
+resource "aws_route53_record" "dkim_record" {
+  count   = 3
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}._domainkey.${data.aws_route53_zone.main.name}"
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
+
+resource "aws_ses_email_identity" "from_email" {
+  email = "keita.koga.work+${terraform.workspace}@gmail.com"
+}

--- a/modules/aws/ses/outputs.tf
+++ b/modules/aws/ses/outputs.tf
@@ -1,0 +1,5 @@
+output "ses" {
+  value = {
+    "email_identity_arn" = aws_ses_email_identity.from_email.arn
+  }
+}

--- a/modules/aws/ses/variable.tf
+++ b/modules/aws/ses/variable.tf
@@ -1,0 +1,7 @@
+variable "public_domain" {
+  type = map(string)
+
+  default = {
+    "default.name" = "keitakn.de"
+  }
+}

--- a/providers/aws/environments/10-ses/backend.tf
+++ b/providers/aws/environments/10-ses/backend.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = "=0.12.29"
+
+  backend "s3" {
+    bucket  = "keitakn-tfstate"
+    key     = "ses/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "nekochans-dev"
+  }
+}
+

--- a/providers/aws/environments/10-ses/main.tf
+++ b/providers/aws/environments/10-ses/main.tf
@@ -1,0 +1,3 @@
+module "ses" {
+  source = "../../../../modules/aws/ses"
+}

--- a/providers/aws/environments/10-ses/output.tf
+++ b/providers/aws/environments/10-ses/output.tf
@@ -1,0 +1,3 @@
+output "ses" {
+  value = module.ses.ses
+}

--- a/providers/aws/environments/10-ses/provider.tf
+++ b/providers/aws/environments/10-ses/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "=2.70.0"
+  region  = "us-east-1"
+  profile = "nekochans-dev"
+}

--- a/providers/aws/environments/10-ses/versions.tf
+++ b/providers/aws/environments/10-ses/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/providers/aws/environments/11-cognito/backend.tf
+++ b/providers/aws/environments/11-cognito/backend.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "=0.12.29"
+
+  backend "s3" {
+    bucket  = "keitakn-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "nekochans-dev"
+  }
+}
+
+data "terraform_remote_state" "ses" {
+  backend = "s3"
+
+  config = {
+    bucket  = "keitakn-tfstate"
+    key     = "env:/${terraform.workspace}/ses/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "nekochans-dev"
+  }
+}
+

--- a/providers/aws/environments/11-cognito/main.tf
+++ b/providers/aws/environments/11-cognito/main.tf
@@ -1,0 +1,4 @@
+module "cognito" {
+  source = "../../../../modules/aws/cognito"
+  ses    = data.terraform_remote_state.ses.outputs.ses
+}

--- a/providers/aws/environments/11-cognito/provider.tf
+++ b/providers/aws/environments/11-cognito/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "=2.70.0"
+  region  = "ap-northeast-1"
+  profile = "nekochans-dev"
+}

--- a/providers/aws/environments/11-cognito/versions.tf
+++ b/providers/aws/environments/11-cognito/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/my-terraform/issues/23

# Doneの定義
- 一般ユーザー向けのCognitoUserPoolの設定が作成されている事

# スクリーンショット

![attributes](https://user-images.githubusercontent.com/11032365/89248756-77dbb480-d64b-11ea-830f-46d614d274c4.png)

# 変更点概要

## 技術的変更点概要
- cognitoのメール送信で利用するのでSES用のリソースを作成
- `aws_cognito_user_pool` を利用しUserPoolを作成

スクリーンショットにも一部情報があるが、UserPoolは以下の設定で作成

- メールアドレス or 電話番号 + パスワード でサインイン可能（ユーザー名では出来ない）
- サインアップ時に必須なパラメータはメールアドレスのみ
- MFAは任意でワンタイムパスワードを利用

# 補足情報
ユーザーのアカウント回復方法は現在非推奨の設定。

![setup_account_recovery_settings](https://user-images.githubusercontent.com/11032365/89250487-d2770f80-d64f-11ea-8478-3f074fe85214.png)

これはTerraformがまだ対応していない為。

以下の記事のように `null_resource` と `local-exec` で実現出来るが、Terraformの実行環境にAWS-CLIを入れないといけないので一旦保留。

```
resource "null_resource" "setup_account_recovery_settings" {
  triggers = {
    version = 1
  }

  provisioner "local-exec" {
    command = "aws cognito-idp update-user-pool --user-pool-id ${aws_cognito_user_pool.pool.id} --account-recovery-setting 'RecoveryMechanisms=[{Priority=1,Name=verified_email},{Priority=2,Name=verified_phone_number}]' --region ap-northeast-1"
  }
}
```

https://stackoverflow.com/questions/59120055/set-account-recovery-preference-for-aws-cognito-user-pool-with-terraform

