### PR TITLE
複数のリダイレクトURIを設定出来る事が分かったのでproviderの名前からprefixを削除し単なるLINEに変更

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -126,7 +126,7 @@ resource "aws_cognito_user_pool_client" "next_idaas_spa_client" {
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
 
-  supported_identity_providers = ["COGNITO", "${terraform.workspace}-LINE"]
+  supported_identity_providers = ["COGNITO", "LINE"]
 
   callback_urls = sort([
     "http://localhost:3900/cognito/authorized",
@@ -146,7 +146,7 @@ resource "aws_cognito_user_pool_client" "next_idaas_spa_client" {
 
 resource "aws_cognito_identity_provider" "line" {
   user_pool_id  = aws_cognito_user_pool.user_pool.id
-  provider_name = "${terraform.workspace}-LINE"
+  provider_name = "LINE"
   provider_type = "OIDC"
 
   provider_details = {


### PR DESCRIPTION
# issueURL
なし

# Doneの定義
- LINE用の `cognito-identity-provider` の名前が変更されている事

# 変更点概要

## 技術的変更点概要
- `aws_cognito_identity_provider.line.provider_name` を変更

# 補足情報
LINEのリダイレクトURIは複数設定出来ないと思い込んでいたが、実は改行すれば複数登録出来る事が判明したので、わざわざ複数のプロバイダを設定しなくても大丈夫と判断し `aws_cognito_identity_provider` の名前から環境変数のprefixを削除した。