### PR TITLE
JWT Authorizerで利用する用のカスタムスコープとクライアントIDを追加

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -148,7 +148,7 @@ resource "aws_cognito_user_pool_client" "next_idaas_server_client" {
 
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows                  = ["client_credentials"]
-  allowed_oauth_scopes                 = ["${aws_cognito_resource_server.cognito_admin_api.name}/admin"]
+  allowed_oauth_scopes                 = ["${aws_cognito_resource_server.cognito_admin_api.identifier}/admin"]
 
   depends_on = [aws_cognito_resource_server.cognito_admin_api]
 }

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -129,8 +129,8 @@ resource "aws_cognito_identity_provider" "facebook" {
 }
 
 resource "aws_cognito_resource_server" "cognito_admin_api" {
-  identifier = "${terraform.workspace}-cognito-admin-api"
   name       = "${terraform.workspace}-cognito-admin-api"
+  identifier = "${terraform.workspace}-cognito-admin-api.keitakn.de"
 
   scope {
     scope_description = "go-cognito-lambdaに実装されているcognitoの管理者用APIの利用権限"


### PR DESCRIPTION
# issueURL
- https://github.com/keitakn/my-terraform/issues/36
- https://github.com/keitakn/go-cognito-lambda/issues/21

# Doneの定義
- CognitoUserPoolにカスタムスコープとクライアントシークレットを持つクライアントIDが発行されている事

# 変更点概要
- https://github.com/keitakn/go-cognito-lambda/pull/22 で作成したAPIを表すリソースサーバーとスコープ定義を追加
- クライアントクレデンシャルでトークンを発行する前提の比較的強力なクライアントIDを追加

# 補足情報
https://github.com/keitakn/go-cognito-lambda/pull/22 のPRと合わせて、JWT AuthorizerでAPIの保護が出来ている事を確認済。
