### PR TITLE
FacebookのgraphAPIから返ってきた値の一部をCognitoUserPoolの属性値にマッピングするように変更

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -123,8 +123,14 @@ resource "aws_cognito_identity_provider" "facebook" {
   }
 
   attribute_mapping = {
-    email    = "email"
-    username = "id"
+    email       = "email"
+    username    = "id"
+    name        = "name"
+    given_name  = "first_name"
+    family_name = "last_name"
+    picture     = "picture"
+    birthdate   = "birthday"
+    locale      = "locale"
   }
 }
 


### PR DESCRIPTION
# issueURL
なし

# Doneの定義
- Facebookログイン実行時にUserPool上にFacebookの値が登録されるようになっている事

# 変更点概要
`attribute_mapping` を以下のように変更。これによってIDトークンにもこれらの値が登録されるようになった。

```
  attribute_mapping = {
    email       = "email"
    username    = "id"
    name        = "name"
    given_name  = "first_name"
    family_name = "last_name"
    picture     = "picture"
    birthdate   = "birthday"
    locale      = "locale"
  }
```