### PR TITLE
Cognitoのサインアップ時にトークンを保存する用のDynamoDBテーブルを作成

### DIFF
--- a/modules/aws/dynamodb/main.tf
+++ b/modules/aws/dynamodb/main.tf
@@ -1,0 +1,35 @@
+resource "aws_dynamodb_table" "authentication_tokens" {
+  name           = lookup(var.authentication_tokens_table, "${terraform.workspace}.name", var.authentication_tokens_table["default.name"])
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "Token"
+
+  attribute {
+    name = "Token"
+    type = "S"
+  }
+
+  attribute {
+    name = "CognitoSub"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ExpirationTime"
+    enabled        = true
+  }
+
+  global_secondary_index {
+    name            = "AuthenticationTokensGlobalIndexCognitoSub"
+    hash_key        = "CognitoSub"
+    write_capacity  = 1
+    read_capacity   = 1
+    projection_type = "ALL"
+  }
+
+  tags = {
+    Name        = lookup(var.authentication_tokens_table, "${terraform.workspace}.name", var.authentication_tokens_table["default.name"])
+    Environment = terraform.workspace
+  }
+}

--- a/modules/aws/dynamodb/variable.tf
+++ b/modules/aws/dynamodb/variable.tf
@@ -1,0 +1,10 @@
+variable "authentication_tokens_table" {
+  type = map(string)
+
+  default = {
+    "default.name" = "ProdAuthenticationTokens"
+    "stg.name"     = "StgAuthenticationTokens"
+    "dev.name"     = "DevAuthenticationTokens"
+    "qa.name"      = "QaAuthenticationTokens"
+  }
+}

--- a/providers/aws/environments/12-dynamodb/backend.tf
+++ b/providers/aws/environments/12-dynamodb/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "=0.12.29"
+
+  backend "s3" {
+    bucket  = "keitakn-tfstate"
+    key     = "dynamodb/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "nekochans-dev"
+  }
+}

--- a/providers/aws/environments/12-dynamodb/main.tf
+++ b/providers/aws/environments/12-dynamodb/main.tf
@@ -1,0 +1,3 @@
+module "dynamodb" {
+  source = "../../../../modules/aws/dynamodb"
+}

--- a/providers/aws/environments/12-dynamodb/provider.tf
+++ b/providers/aws/environments/12-dynamodb/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "=2.70.0"
+  region  = "ap-northeast-1"
+  profile = "nekochans-dev"
+}

--- a/providers/aws/environments/12-dynamodb/versions.tf
+++ b/providers/aws/environments/12-dynamodb/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/my-terraform/issues/41

# Doneの定義
- https://github.com/keitakn/my-terraform/issues/41 の完了の定義を満たしている事
- https://github.com/keitakn/go-cognito-lambda/pull/29 で動作確認が完了している事

# 変更点概要
https://github.com/keitakn/go-cognito-lambda/pull/29 で利用する認証トークン用のテーブルを追加。