### PR TITLE
authenticationFlowType: CUSTOM_AUTH を利用出来るように設定を変更

### DIFF
--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -61,7 +61,7 @@ resource "aws_cognito_user_pool_client" "next_idaas_spa_client" {
   generate_secret               = false
   prevent_user_existence_errors = "ENABLED"
   refresh_token_validity        = 30
-  explicit_auth_flows           = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  explicit_auth_flows           = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_CUSTOM_AUTH"]
 
   supported_identity_providers = ["COGNITO", "LINE", "Facebook"]
 


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/13

# Doneの定義
- SPA用のCognitoのクライアントIDがカスタム認証を利用出来る状態になっている事

# 変更点概要
`explicit_auth_flows ` に `ALLOW_CUSTOM_AUTH` を追加。