### PR TITLE
Terraformの初期化スクリプトに11-cognitoがなかったので追加

### DIFF
--- a/terraform-init-dev.sh
+++ b/terraform-init-dev.sh
@@ -4,6 +4,7 @@ tfstateDirList='
 /app/my-terraform/providers/aws/environments/10-network
 /app/my-terraform/providers/aws/environments/10-ssm
 /app/my-terraform/providers/aws/environments/11-ecr
+/app/my-terraform/providers/aws/environments/11-cognito
 /app/my-terraform/providers/aws/environments/20-api
 /app/my-terraform/providers/aws/environments/20-eks
 '


### PR DESCRIPTION
# issueURL
なし

# Doneの定義
- `terraform-init-dev.sh` を実行した時に全ての `tfstate` が初期化されている事

# 変更点概要
- `providers/aws/environments/11-cognito` を実行対象に追加