### PR TITLE
Terraformのバージョンを0.13にアップグレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.29
+FROM hashicorp/terraform:0.13.6
 
 RUN mkdir -p /app/my-terraform
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ docker-compose exec terraform ./terraform-init-dev.sh
 1. `providers/aws/environments/10-network/`
 1. `providers/aws/environments/10-ssm/`
 1. `providers/aws/environments/11-ecr/`
+1. `providers/aws/environments/11-cognito/`
 1. `providers/aws/environments/20-api/`
 1. `providers/aws/environments/20-eks`
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ docker-compose exec terraform ./terraform-init-dev.sh
 ```
 
 1. `providers/aws/environments/10-network/`
+1. `providers/aws/environments/10-ses/`
 1. `providers/aws/environments/10-ssm/`
 1. `providers/aws/environments/11-ecr/`
 1. `providers/aws/environments/11-cognito/`

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ docker-compose exec terraform ./terraform-init-dev.sh
 1. `providers/aws/environments/10-ssm/`
 1. `providers/aws/environments/11-ecr/`
 1. `providers/aws/environments/11-cognito/`
+1. `providers/aws/environments/12-dynamodb/`
 1. `providers/aws/environments/20-api/`
 1. `providers/aws/environments/20-eks`
 

--- a/modules/aws/api/versions.tf
+++ b/modules/aws/api/versions.tf
@@ -1,3 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }

--- a/modules/aws/cognito/versions.tf
+++ b/modules/aws/cognito/versions.tf
@@ -1,11 +1,8 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
       source = "hashicorp/aws"
     }
-    external = {
-      source = "hashicorp/external"
-    }
   }
+  required_version = ">= 0.13"
 }

--- a/modules/aws/dynamodb/versions.tf
+++ b/modules/aws/dynamodb/versions.tf
@@ -1,11 +1,8 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
       source = "hashicorp/aws"
     }
-    external = {
-      source = "hashicorp/external"
-    }
   }
+  required_version = ">= 0.13"
 }

--- a/modules/aws/ecr/versions.tf
+++ b/modules/aws/ecr/versions.tf
@@ -1,4 +1,8 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/modules/aws/ses/versions.tf
+++ b/modules/aws/ses/versions.tf
@@ -1,11 +1,8 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
       source = "hashicorp/aws"
     }
-    external = {
-      source = "hashicorp/external"
-    }
   }
+  required_version = ">= 0.13"
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/10-network/backend.tf
+++ b/providers/aws/environments/10-network/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"

--- a/providers/aws/environments/10-network/main.tf
+++ b/providers/aws/environments/10-network/main.tf
@@ -3,11 +3,11 @@ module "vpc" {
   availability_zone = var.default_az
 }
 
-//module "vpc_us_east_1" {
-//  source            = "../../../../modules/aws/vpc"
-//  availability_zone = var.us_east_1_az
-//
-//  providers = {
-//    aws = aws.us_east_1
-//  }
-//}
+module "vpc_us_east_1" {
+  source            = "../../../../modules/aws/vpc"
+  availability_zone = var.us_east_1_az
+
+  providers = {
+    aws = aws.us_east_1
+  }
+}

--- a/providers/aws/environments/10-network/output.tf
+++ b/providers/aws/environments/10-network/output.tf
@@ -2,6 +2,6 @@ output "vpc" {
   value = module.vpc.vpc
 }
 
-//output "vpc_us_east_1" {
-//  value = module.vpc_us_east_1.vpc
-//}
+output "vpc_us_east_1" {
+  value = module.vpc_us_east_1.vpc
+}

--- a/providers/aws/environments/10-network/provider.tf
+++ b/providers/aws/environments/10-network/provider.tf
@@ -4,9 +4,9 @@ provider "aws" {
   profile = "nekochans-dev"
 }
 
-//provider "aws" {
-//  version = "=2.46.0"
-//  region  = "us-east-1"
-//  profile = "nekochans-dev"
-//  alias   = "us_east_1"
-//}
+provider "aws" {
+  version = "=2.70.0"
+  region  = "us-east-1"
+  profile = "nekochans-dev"
+  alias   = "us_east_1"
+}

--- a/providers/aws/environments/10-network/variable.tf
+++ b/providers/aws/environments/10-network/variable.tf
@@ -8,12 +8,12 @@ variable "default_az" {
   }
 }
 
-//variable "us_east_1_az" {
-//  type = map(string)
-//
-//  default = {
-//    "default.az_1" = "us-east-1a"
-//    "default.az_2" = "us-east-1b"
-//    "default.az_3" = "us-east-1b"
-//  }
-//}
+variable "us_east_1_az" {
+  type = map(string)
+
+  default = {
+    "default.az_1" = "us-east-1a"
+    "default.az_2" = "us-east-1b"
+    "default.az_3" = "us-east-1b"
+  }
+}

--- a/providers/aws/environments/10-network/versions.tf
+++ b/providers/aws/environments/10-network/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/10-ses/backend.tf
+++ b/providers/aws/environments/10-ses/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"
@@ -8,4 +8,3 @@ terraform {
     profile = "nekochans-dev"
   }
 }
-

--- a/providers/aws/environments/10-ses/versions.tf
+++ b/providers/aws/environments/10-ses/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/10-ssm/backend.tf
+++ b/providers/aws/environments/10-ssm/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"

--- a/providers/aws/environments/10-ssm/versions.tf
+++ b/providers/aws/environments/10-ssm/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/11-cognito/backend.tf
+++ b/providers/aws/environments/11-cognito/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"
@@ -19,4 +19,3 @@ data "terraform_remote_state" "ses" {
     profile = "nekochans-dev"
   }
 }
-

--- a/providers/aws/environments/11-cognito/versions.tf
+++ b/providers/aws/environments/11-cognito/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/11-ecr/backend.tf
+++ b/providers/aws/environments/11-ecr/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"

--- a/providers/aws/environments/11-ecr/versions.tf
+++ b/providers/aws/environments/11-ecr/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/12-dynamodb/backend.tf
+++ b/providers/aws/environments/12-dynamodb/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"

--- a/providers/aws/environments/12-dynamodb/versions.tf
+++ b/providers/aws/environments/12-dynamodb/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/20-api/backend.tf
+++ b/providers/aws/environments/20-api/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"

--- a/providers/aws/environments/20-api/versions.tf
+++ b/providers/aws/environments/20-api/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/providers/aws/environments/20-eks/backend.tf
+++ b/providers/aws/environments/20-eks/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "=0.12.29"
+  required_version = "=0.13.6"
 
   backend "s3" {
     bucket  = "keitakn-tfstate"

--- a/providers/aws/environments/20-eks/versions.tf
+++ b/providers/aws/environments/20-eks/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform-init-dev.sh
+++ b/terraform-init-dev.sh
@@ -2,6 +2,7 @@
 
 tfstateDirList='
 /app/my-terraform/providers/aws/environments/10-network
+/app/my-terraform/providers/aws/environments/10-ses
 /app/my-terraform/providers/aws/environments/10-ssm
 /app/my-terraform/providers/aws/environments/11-ecr
 /app/my-terraform/providers/aws/environments/11-cognito

--- a/terraform-init-dev.sh
+++ b/terraform-init-dev.sh
@@ -6,6 +6,7 @@ tfstateDirList='
 /app/my-terraform/providers/aws/environments/10-ssm
 /app/my-terraform/providers/aws/environments/11-ecr
 /app/my-terraform/providers/aws/environments/11-cognito
+/app/my-terraform/providers/aws/environments/12-dynamodb
 /app/my-terraform/providers/aws/environments/20-api
 /app/my-terraform/providers/aws/environments/20-eks
 '


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/my-terraform/issues/31

# Doneの定義
- Terraformのバージョンが0.13系に更新されている事
- 0.13系で `terraform apply` が実施されている事

# 変更点概要

以下のコマンドを実施し変更内容をコミットした。

`find . -name '*.tf' | xargs -n1 dirname | uniq | xargs -n1 terraform 0.13upgrade -yes`

その後、 `terraform apply` を実施しリソースが正常に作成される事を確認済。

# 補足情報
初期化用のscriptである `terraform-init-dev.sh` に追加されていないディレクトリがあったのでこの機会に追加してある。