### PR TITLE
Terraformのバージョンを0.14にアップグレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.13.6
+FROM hashicorp/terraform:0.14.6
 
 RUN mkdir -p /app/my-terraform
 

--- a/modules/aws/api/versions.tf
+++ b/modules/aws/api/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/cognito/versions.tf
+++ b/modules/aws/cognito/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
 }

--- a/modules/aws/dynamodb/versions.tf
+++ b/modules/aws/dynamodb/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
 }

--- a/modules/aws/ecr/versions.tf
+++ b/modules/aws/ecr/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/ses/versions.tf
+++ b/modules/aws/ses/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
 }

--- a/modules/aws/ssm/main.tf
+++ b/modules/aws/ssm/main.tf
@@ -18,39 +18,29 @@ data "aws_secretsmanager_secret_version" "sendgrid_secret" {
   secret_id = data.aws_secretsmanager_secret.sendgrid_secret.id
 }
 
-// terraformのExternal Data Sourceを使ってSeecretManagerのJSONをデコードする
-// https://www.terraform.io/docs/providers/external/data_source.html
-data "external" "slack_secret_json" {
-  program = ["echo", data.aws_secretsmanager_secret_version.slack_secret.secret_string]
-}
-
-data "external" "sendgrid_secret_json" {
-  program = ["echo", data.aws_secretsmanager_secret_version.sendgrid_secret.secret_string]
-}
-
 // デコードしたJSONを元にパラメータストアを作成する
 resource "aws_ssm_parameter" "news_app_slack_token" {
   name  = "/${terraform.workspace}/test-app/news/slack-token"
   type  = "SecureString"
-  value = data.external.slack_secret_json.result["TOKEN"]
+  value = jsondecode(data.aws_secretsmanager_secret_version.slack_secret.secret_string)["TOKEN"]
 }
 
 resource "aws_ssm_parameter" "news_app_sendgrid_api_key" {
   name  = "/${terraform.workspace}/test-app/news/sendgrid-api-key"
   type  = "SecureString"
-  value = data.external.sendgrid_secret_json.result["API_KEY"]
+  value = jsondecode(data.aws_secretsmanager_secret_version.sendgrid_secret.secret_string)["API_KEY"]
 }
 
 resource "aws_ssm_parameter" "weather_app_slack_token" {
   name  = "/${terraform.workspace}/test-app/weather/slack-token"
   type  = "SecureString"
-  value = data.external.slack_secret_json.result["TOKEN"]
+  value = jsondecode(data.aws_secretsmanager_secret_version.slack_secret.secret_string)["TOKEN"]
 }
 
 resource "aws_ssm_parameter" "weather_app_sendgrid_api_key" {
   name  = "/${terraform.workspace}/test-app/weather/sendgrid-api-key"
   type  = "SecureString"
-  value = data.external.sendgrid_secret_json.result["API_KEY"]
+  value = jsondecode(data.aws_secretsmanager_secret_version.sendgrid_secret.secret_string)["API_KEY"]
 }
 
 // AWS.SSM. getParametersByPath のリミット件数をテストする為のresources

--- a/modules/aws/ssm/versions.tf
+++ b/modules/aws/ssm/versions.tf
@@ -1,11 +1,8 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
-    }
-    external = {
-      source = "hashicorp/external"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/providers/aws/environments/10-network/.terraform.lock.hcl
+++ b/providers/aws/environments/10-network/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/10-network/backend.tf
+++ b/providers/aws/environments/10-network/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "network/terraform.tfstate"

--- a/providers/aws/environments/10-network/provider.tf
+++ b/providers/aws/environments/10-network/provider.tf
@@ -1,11 +1,9 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "ap-northeast-1"
   profile = "nekochans-dev"
 }
 
 provider "aws" {
-  version = "=2.70.0"
   region  = "us-east-1"
   profile = "nekochans-dev"
   alias   = "us_east_1"

--- a/providers/aws/environments/10-network/versions.tf
+++ b/providers/aws/environments/10-network/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/10-network/versions.tf
+++ b/providers/aws/environments/10-network/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }

--- a/providers/aws/environments/10-ses/.terraform.lock.hcl
+++ b/providers/aws/environments/10-ses/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/10-ses/backend.tf
+++ b/providers/aws/environments/10-ses/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "ses/terraform.tfstate"

--- a/providers/aws/environments/10-ses/provider.tf
+++ b/providers/aws/environments/10-ses/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "us-east-1"
   profile = "nekochans-dev"
 }

--- a/providers/aws/environments/10-ses/versions.tf
+++ b/providers/aws/environments/10-ses/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/10-ses/versions.tf
+++ b/providers/aws/environments/10-ses/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }

--- a/providers/aws/environments/10-ssm/.terraform.lock.hcl
+++ b/providers/aws/environments/10-ssm/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/10-ssm/backend.tf
+++ b/providers/aws/environments/10-ssm/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "ssm/terraform.tfstate"

--- a/providers/aws/environments/10-ssm/provider.tf
+++ b/providers/aws/environments/10-ssm/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "ap-northeast-1"
   profile = "nekochans-dev"
 }

--- a/providers/aws/environments/10-ssm/versions.tf
+++ b/providers/aws/environments/10-ssm/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/10-ssm/versions.tf
+++ b/providers/aws/environments/10-ssm/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }

--- a/providers/aws/environments/11-cognito/.terraform.lock.hcl
+++ b/providers/aws/environments/11-cognito/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/11-cognito/backend.tf
+++ b/providers/aws/environments/11-cognito/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "cognito/terraform.tfstate"

--- a/providers/aws/environments/11-cognito/provider.tf
+++ b/providers/aws/environments/11-cognito/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "ap-northeast-1"
   profile = "nekochans-dev"
 }

--- a/providers/aws/environments/11-cognito/versions.tf
+++ b/providers/aws/environments/11-cognito/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/11-cognito/versions.tf
+++ b/providers/aws/environments/11-cognito/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }

--- a/providers/aws/environments/11-ecr/.terraform.lock.hcl
+++ b/providers/aws/environments/11-ecr/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/11-ecr/backend.tf
+++ b/providers/aws/environments/11-ecr/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "ecr/terraform.tfstate"

--- a/providers/aws/environments/11-ecr/provider.tf
+++ b/providers/aws/environments/11-ecr/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "ap-northeast-1"
   profile = "nekochans-dev"
 }

--- a/providers/aws/environments/11-ecr/versions.tf
+++ b/providers/aws/environments/11-ecr/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/11-ecr/versions.tf
+++ b/providers/aws/environments/11-ecr/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }

--- a/providers/aws/environments/12-dynamodb/.terraform.lock.hcl
+++ b/providers/aws/environments/12-dynamodb/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/12-dynamodb/backend.tf
+++ b/providers/aws/environments/12-dynamodb/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "dynamodb/terraform.tfstate"

--- a/providers/aws/environments/12-dynamodb/provider.tf
+++ b/providers/aws/environments/12-dynamodb/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "ap-northeast-1"
   profile = "nekochans-dev"
 }

--- a/providers/aws/environments/12-dynamodb/versions.tf
+++ b/providers/aws/environments/12-dynamodb/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/12-dynamodb/versions.tf
+++ b/providers/aws/environments/12-dynamodb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }

--- a/providers/aws/environments/20-api/.terraform.lock.hcl
+++ b/providers/aws/environments/20-api/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/providers/aws/environments/20-api/backend.tf
+++ b/providers/aws/environments/20-api/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "api/terraform.tfstate"

--- a/providers/aws/environments/20-api/provider.tf
+++ b/providers/aws/environments/20-api/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "ap-northeast-1"
   profile = "nekochans-dev"
 }

--- a/providers/aws/environments/20-api/versions.tf
+++ b/providers/aws/environments/20-api/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/20-api/versions.tf
+++ b/providers/aws/environments/20-api/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }

--- a/providers/aws/environments/20-eks/.terraform.lock.hcl
+++ b/providers/aws/environments/20-eks/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/20-eks/backend.tf
+++ b/providers/aws/environments/20-eks/backend.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = "=0.13.6"
-
   backend "s3" {
     bucket  = "keitakn-tfstate"
     key     = "eks/terraform.tfstate"

--- a/providers/aws/environments/20-eks/provider.tf
+++ b/providers/aws/environments/20-eks/provider.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "=2.70.0"
   region  = "ap-northeast-1"
   profile = "nekochans-dev"
 }

--- a/providers/aws/environments/20-eks/versions.tf
+++ b/providers/aws/environments/20-eks/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "3.28.0"
     }
   }
 }

--- a/providers/aws/environments/20-eks/versions.tf
+++ b/providers/aws/environments/20-eks/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.28.0"
     }
   }


### PR DESCRIPTION
# issueURL
- https://github.com/keitakn/my-terraform/issues/46
- https://github.com/keitakn/my-terraform/issues/35

# Doneの定義
- Terraformのバージョンが `0.14` 系にアップグレードされている事
- terraform-provider-awsのversionが3系の最新に更新されている事
- `terraform apply` が実施されている事

# 変更点概要
- 0.14系にUpgradeした際に追加された `.terraform.lock.hcl` を追加
- externalModuleへの依存はトラブルが多いので、標準関数を使った形に書き換え
- DockerfileのTerraformのバージョンを0.14に変更

# 補足情報

https://github.com/keitakn/my-terraform/pull/48/commits/744828da297f736ca0499192adaadcb0b4325e3f を実行した際に再作成を余儀なくされた本プロジェクトは実験用のプロジェクトなので問題はないが実運用しているプロジェクトだと大きな問題が発生するので、事前にexternalModuleへの依存は取り除いていたほうが良いという教訓を得た。