### PR TITLE
RDS Proxyの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ docker-compose exec terraform ./terraform-init-dev.sh
 1. `providers/aws/environments/11-ecr/`
 1. `providers/aws/environments/11-cognito/`
 1. `providers/aws/environments/12-dynamodb/`
+1. `providers/aws/environments/13-lambda/`
+1. `providers/aws/environments/14-rds/`
 1. `providers/aws/environments/20-api/`
 1. `providers/aws/environments/20-eks`
 

--- a/modules/aws/rds/bastion.tf
+++ b/modules/aws/rds/bastion.tf
@@ -1,0 +1,78 @@
+resource "aws_iam_instance_profile" "bastion_instance_profile" {
+  name = lookup(var.bastion, "${terraform.workspace}.name", var.bastion["default.name"])
+  role = aws_iam_role.bastion_role.name
+}
+
+resource "aws_security_group" "bastion" {
+  name = "${terraform.workspace}-${lookup(
+    var.bastion,
+    "${terraform.workspace}.name",
+    var.bastion["default.name"],
+  )}"
+  description = "Security Group to ${lookup(
+    var.bastion,
+    "${terraform.workspace}.name",
+    var.bastion["default.name"],
+  )}"
+  vpc_id = var.vpc["vpc_id"]
+
+  tags = {
+    Name = "${terraform.workspace}-${lookup(
+      var.bastion,
+      "${terraform.workspace}.name",
+      var.bastion["default.name"],
+    )}"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "bastion" {
+  ami = lookup(
+    var.bastion,
+    "${terraform.workspace}.ami",
+    var.bastion["default.ami"],
+  )
+  associate_public_ip_address = false
+  instance_type = lookup(
+    var.bastion,
+    "${terraform.workspace}.instance_type",
+    var.bastion["default.instance_type"],
+  )
+
+  iam_instance_profile = aws_iam_instance_profile.bastion_instance_profile.name
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = lookup(
+      var.bastion,
+      "${terraform.workspace}.volume_type",
+      var.bastion["default.volume_type"],
+    )
+    volume_size = lookup(
+      var.bastion,
+      "${terraform.workspace}.volume_size",
+      var.bastion["default.volume_size"],
+    )
+  }
+
+  subnet_id              = var.vpc["subnet_private_3"]
+  vpc_security_group_ids = [aws_security_group.bastion.id]
+
+  tags = {
+    Name = "${terraform.workspace}-${lookup(
+      var.bastion,
+      "${terraform.workspace}.name",
+      var.bastion["default.name"],
+    )}"
+  }
+
+  lifecycle {
+    ignore_changes = all
+  }
+}

--- a/modules/aws/rds/bastion.tf
+++ b/modules/aws/rds/bastion.tf
@@ -38,7 +38,7 @@ resource "aws_instance" "bastion" {
     "${terraform.workspace}.ami",
     var.bastion["default.ami"],
   )
-  associate_public_ip_address = false
+  associate_public_ip_address = true
   instance_type = lookup(
     var.bastion,
     "${terraform.workspace}.instance_type",
@@ -61,7 +61,7 @@ resource "aws_instance" "bastion" {
     )
   }
 
-  subnet_id              = var.vpc["subnet_private_3"]
+  subnet_id              = var.vpc["subnet_public_3"]
   vpc_security_group_ids = [aws_security_group.bastion.id]
 
   tags = {

--- a/modules/aws/rds/files/policy/rds-proxy-policy.json
+++ b/modules/aws/rds/files/policy/rds-proxy-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetResourcePolicy",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecretVersionIds"
+      ],
+      "Resource": "arn:aws:secretsmanager:*:*:*"
+    }
+  ]
+}

--- a/modules/aws/rds/iam.tf
+++ b/modules/aws/rds/iam.tf
@@ -46,3 +46,26 @@ resource "aws_iam_role_policy_attachment" "bastion_role_attachment" {
   role       = aws_iam_role.bastion_role.name
   policy_arn = data.aws_iam_policy.systems_manager.arn
 }
+
+// RDS Proxy用のIAM
+data "aws_iam_policy_document" "rds_proxy_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "rds_proxy_role" {
+  name               = "${terraform.workspace}-rds-proxy-role"
+  assume_role_policy = data.aws_iam_policy_document.rds_proxy_assume_role.json
+}
+
+resource "aws_iam_role_policy" "rds_proxy_policy" {
+  name   = "${terraform.workspace}-rds-proxy-policy"
+  role   = aws_iam_role.rds_proxy_role.id
+  policy = file("../../../../modules/aws/rds/files/policy/rds-proxy-policy.json")
+}

--- a/modules/aws/rds/iam.tf
+++ b/modules/aws/rds/iam.tf
@@ -20,3 +20,29 @@ resource "aws_iam_role_policy_attachment" "rds_monitoring_attachment" {
   role       = aws_iam_role.rds_monitoring_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
+
+// ここから下は接続確認用のEC2の為のIAMロール
+data "aws_iam_policy_document" "assume_bastion_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "bastion_role" {
+  name               = lookup(var.bastion, "${terraform.workspace}.name", var.bastion["default.name"])
+  assume_role_policy = data.aws_iam_policy_document.assume_bastion_role.json
+}
+
+data "aws_iam_policy" "systems_manager" {
+  arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_role_attachment" {
+  role       = aws_iam_role.bastion_role.name
+  policy_arn = data.aws_iam_policy.systems_manager.arn
+}

--- a/modules/aws/rds/iam.tf
+++ b/modules/aws/rds/iam.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "rds_monitoring_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "rds_monitoring_role" {
+  name               = "${terraform.workspace}-rds-monitoring"
+  assume_role_policy = data.aws_iam_policy_document.rds_monitoring_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring_attachment" {
+  role       = aws_iam_role.rds_monitoring_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -15,6 +15,15 @@ resource "aws_security_group" "rds_cluster" {
   }
 }
 
+resource "aws_security_group_rule" "rds_from_bastion_server" {
+  security_group_id        = aws_security_group.rds_cluster.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+}
+
 resource "aws_db_subnet_group" "rds_subnet_group" {
   name        = lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])
   description = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-subnet-group"

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -39,9 +39,9 @@ resource "aws_db_subnet_group" "rds_subnet_group" {
   description = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-subnet-group"
 
   subnet_ids = [
-    var.vpc["subnet_private_1"],
-    var.vpc["subnet_private_2"],
-    var.vpc["subnet_private_3"],
+    var.vpc["subnet_public_1"],
+    var.vpc["subnet_public_2"],
+    var.vpc["subnet_public_3"],
   ]
 }
 

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -24,6 +24,16 @@ resource "aws_security_group_rule" "rds_from_bastion_server" {
   source_security_group_id = aws_security_group.bastion.id
 }
 
+resource "aws_security_group_rule" "rds_from_rds_proxy" {
+  security_group_id        = aws_security_group.rds_cluster.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.rds_proxy.id
+  depends_on               = [aws_security_group.rds_proxy]
+}
+
 resource "aws_db_subnet_group" "rds_subnet_group" {
   name        = lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])
   description = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-subnet-group"

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -1,0 +1,162 @@
+resource "aws_security_group" "rds_cluster" {
+  name        = lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])
+  description = "Security Group to ${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}"
+  vpc_id      = var.vpc["vpc_id"]
+
+  tags = {
+    Name = lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name        = lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])
+  description = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-subnet-group"
+
+  subnet_ids = [
+    var.vpc["subnet_private_1"],
+    var.vpc["subnet_private_2"],
+    var.vpc["subnet_private_3"],
+  ]
+}
+
+resource "aws_db_parameter_group" "rds_parameter_group" {
+  name   = lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])
+  family = "aurora-mysql5.7"
+
+  description = "Database parameter group"
+
+  parameter {
+    name  = "long_query_time"
+    value = "0.1"
+  }
+
+  parameter {
+    name  = "slow_query_log"
+    value = "1"
+  }
+}
+
+resource "aws_rds_cluster_parameter_group" "rds_cluster_parameter_group" {
+  name        = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-cluster"
+  family      = "aurora-mysql5.7"
+  description = "Cluster parameter group for ${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}"
+
+  parameter {
+    name  = "character_set_client"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_connection"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_database"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_filesystem"
+    value = "binary"
+  }
+
+  parameter {
+    name  = "character_set_results"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "collation_connection"
+    value = "utf8mb4_bin"
+  }
+
+  parameter {
+    name  = "collation_server"
+    value = "utf8mb4_bin"
+  }
+
+  parameter {
+    name         = "character-set-client-handshake"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "time_zone"
+    value = "Asia/Tokyo"
+  }
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "aws_rds_cluster" "rds_cluster" {
+  cluster_identifier              = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-cluster"
+  master_username                 = jsondecode(data.aws_secretsmanager_secret_version.rds_secret.secret_string)["USERNAME"]
+  master_password                 = jsondecode(data.aws_secretsmanager_secret_version.rds_secret.secret_string)["PASSWORD"]
+  backup_retention_period         = 5
+  preferred_backup_window         = "19:30-20:00"
+  skip_final_snapshot             = true
+  storage_encrypted               = false
+  vpc_security_group_ids          = [aws_security_group.rds_cluster.id]
+  preferred_maintenance_window    = "wed:20:15-wed:20:45"
+  db_subnet_group_name            = aws_db_subnet_group.rds_subnet_group.name
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_cluster_parameter_group.name
+  engine = lookup(
+    var.rds,
+    "${terraform.workspace}.engine",
+    var.rds["default.engine"]
+  )
+  engine_version = lookup(
+    var.rds,
+    "${terraform.workspace}.engine_version",
+    var.rds["default.engine_version"]
+  )
+}
+
+resource "aws_rds_cluster_instance" "rds_cluster_instance" {
+  count = lookup(
+    var.rds,
+    "${terraform.workspace}.instance_count",
+    var.rds["default.instance_count"]
+  )
+  cluster_identifier = aws_rds_cluster.rds_cluster.id
+  instance_class = lookup(
+    var.rds,
+    "${terraform.workspace}.instance_class",
+    var.rds["default.instance_class"]
+  )
+  engine = lookup(
+    var.rds,
+    "${terraform.workspace}.engine",
+    var.rds["default.engine"]
+  )
+  engine_version = lookup(
+    var.rds,
+    "${terraform.workspace}.engine_version",
+    var.rds["default.engine_version"]
+  )
+  identifier              = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-${count.index}"
+  db_subnet_group_name    = aws_db_subnet_group.rds_subnet_group.name
+  db_parameter_group_name = aws_db_parameter_group.rds_parameter_group.name
+  monitoring_role_arn     = aws_iam_role.rds_monitoring_role.arn
+  monitoring_interval     = 60
+
+  tags = {
+    Name = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-${count.index}"
+  }
+}

--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -54,14 +54,14 @@ resource "aws_db_proxy" "rds_proxy" {
   name                   = "${terraform.workspace}-rds-proxy"
   debug_logging          = false
   engine_family          = "MYSQL"
-  idle_client_timeout    = 1800
+  idle_client_timeout    = 120
   require_tls            = false
   role_arn               = aws_iam_role.rds_proxy_role.arn
   vpc_security_group_ids = [aws_security_group.rds_proxy.id]
   vpc_subnet_ids = [
-    var.vpc["subnet_private_1"],
-    var.vpc["subnet_private_2"],
-    var.vpc["subnet_private_3"],
+    var.vpc["subnet_public_1"],
+    var.vpc["subnet_public_2"],
+    var.vpc["subnet_public_3"],
   ]
 
   auth {
@@ -93,9 +93,9 @@ resource "aws_db_proxy_endpoint" "read_only" {
   db_proxy_name          = aws_db_proxy.rds_proxy.name
   db_proxy_endpoint_name = "${terraform.workspace}-read-only"
   vpc_subnet_ids = [
-    var.vpc["subnet_private_1"],
-    var.vpc["subnet_private_2"],
-    var.vpc["subnet_private_3"],
+    var.vpc["subnet_public_1"],
+    var.vpc["subnet_public_2"],
+    var.vpc["subnet_public_3"],
   ]
   vpc_security_group_ids = [aws_security_group.rds_proxy.id]
   target_role            = "READ_ONLY"

--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -1,0 +1,92 @@
+// 接続確認用のLambda関数
+resource "aws_security_group" "vpc_lambda" {
+  name        = "${terraform.workspace}-vpc-lambda"
+  description = "vpc lambda security group"
+  vpc_id      = var.vpc["vpc_id"]
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "rds_proxy" {
+  name        = "${terraform.workspace}-rds-proxy"
+  description = "rds proxy security group"
+  vpc_id      = var.vpc["vpc_id"]
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.vpc_lambda.id, aws_security_group.bastion.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_proxy" "rds_proxy" {
+  name                   = "${terraform.workspace}-rds-proxy"
+  debug_logging          = false
+  engine_family          = "MYSQL"
+  idle_client_timeout    = 1800
+  require_tls            = false
+  role_arn               = aws_iam_role.rds_proxy_role.arn
+  vpc_security_group_ids = [aws_security_group.rds_proxy.id]
+  vpc_subnet_ids = [
+    var.vpc["subnet_private_1"],
+    var.vpc["subnet_private_2"],
+    var.vpc["subnet_private_3"],
+  ]
+
+  auth {
+    auth_scheme = "SECRETS"
+    iam_auth    = "DISABLED"
+    secret_arn  = aws_secretsmanager_secret.rds_connection_info.arn
+  }
+
+  depends_on = [aws_rds_cluster.rds_cluster, aws_secretsmanager_secret_version.rds_connection_info]
+}
+
+resource "aws_db_proxy_default_target_group" "rds_proxy" {
+  db_proxy_name = aws_db_proxy.rds_proxy.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = 120
+    max_connections_percent      = 100
+    max_idle_connections_percent = 50
+  }
+}
+
+resource "aws_db_proxy_target" "rds_proxy" {
+  db_cluster_identifier = aws_rds_cluster.rds_cluster.id
+  db_proxy_name         = aws_db_proxy.rds_proxy.name
+  target_group_name     = aws_db_proxy_default_target_group.rds_proxy.name
+}
+
+resource "aws_db_proxy_endpoint" "read_only" {
+  db_proxy_name          = aws_db_proxy.rds_proxy.name
+  db_proxy_endpoint_name = "${terraform.workspace}-read-only"
+  vpc_subnet_ids = [
+    var.vpc["subnet_private_1"],
+    var.vpc["subnet_private_2"],
+    var.vpc["subnet_private_3"],
+  ]
+  target_role = "READ_ONLY"
+
+  depends_on = [aws_db_proxy.rds_proxy]
+}

--- a/modules/aws/rds/route53.tf
+++ b/modules/aws/rds/route53.tf
@@ -1,0 +1,29 @@
+resource "aws_route53_zone" "rds_local_domain_name" {
+  name = terraform.workspace
+
+  vpc {
+    vpc_id = var.vpc["vpc_id"]
+  }
+
+  comment = "${terraform.workspace} RDS Local Domain"
+
+  force_destroy = true
+}
+
+resource "aws_route53_record" "rds_local_writer_domain_record" {
+  zone_id = aws_route53_zone.rds_local_domain_name.zone_id
+  name    = var.rds_local_writer_domain_name
+  type    = "CNAME"
+
+  ttl     = 300
+  records = [aws_rds_cluster.rds_cluster.endpoint]
+}
+
+resource "aws_route53_record" "rds_local_reader_domain_record" {
+  zone_id = aws_route53_zone.rds_local_domain_name.zone_id
+  name    = var.rds_local_reader_domain_name
+  type    = "CNAME"
+
+  ttl     = 300
+  records = [aws_rds_cluster.rds_cluster.reader_endpoint]
+}

--- a/modules/aws/rds/secretsmanager.tf
+++ b/modules/aws/rds/secretsmanager.tf
@@ -7,12 +7,14 @@ data "aws_secretsmanager_secret_version" "rds_secret" {
 }
 
 // RDS Proxyから利用する接続情報
-resource "aws_secretsmanager_secret" "rds_connection_info" {
-  name = "${terraform.workspace}/keitakn/rds-connection-info"
+// AWS Secrets Managerは一度削除すると7日間は同じ名前を再定義出来ない、対処法は下記を参照
+// https://aws.amazon.com/jp/premiumsupport/knowledge-center/delete-secrets-manager-secret/
+resource "aws_secretsmanager_secret" "rds_connection" {
+  name = "${terraform.workspace}/keitakn/rds-connection"
 }
 
-resource "aws_secretsmanager_secret_version" "rds_connection_info" {
-  secret_id = aws_secretsmanager_secret.rds_connection_info.id
+resource "aws_secretsmanager_secret_version" "rds_connection" {
+  secret_id = aws_secretsmanager_secret.rds_connection.id
 
   secret_string = jsonencode({
     username : aws_rds_cluster.rds_cluster.master_username

--- a/modules/aws/rds/secretsmanager.tf
+++ b/modules/aws/rds/secretsmanager.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret" "rds_secret" {
+  name = "${terraform.workspace}/keitakn/rds"
+}
+
+data "aws_secretsmanager_secret_version" "rds_secret" {
+  secret_id = data.aws_secretsmanager_secret.rds_secret.id
+}

--- a/modules/aws/rds/secretsmanager.tf
+++ b/modules/aws/rds/secretsmanager.tf
@@ -5,3 +5,21 @@ data "aws_secretsmanager_secret" "rds_secret" {
 data "aws_secretsmanager_secret_version" "rds_secret" {
   secret_id = data.aws_secretsmanager_secret.rds_secret.id
 }
+
+// RDS Proxyから利用する接続情報
+resource "aws_secretsmanager_secret" "rds_connection_info" {
+  name = "${terraform.workspace}/keitakn/rds-connection-info"
+}
+
+resource "aws_secretsmanager_secret_version" "rds_connection_info" {
+  secret_id = aws_secretsmanager_secret.rds_connection_info.id
+
+  secret_string = jsonencode({
+    username : aws_rds_cluster.rds_cluster.master_username
+    password : aws_rds_cluster.rds_cluster.master_password
+    engine : "mysql"
+    host : aws_rds_cluster.rds_cluster.endpoint
+    port : aws_rds_cluster.rds_cluster.port
+    dbClusterIdentifier : aws_rds_cluster.rds_cluster.id
+  })
+}

--- a/modules/aws/rds/variable.tf
+++ b/modules/aws/rds/variable.tf
@@ -1,0 +1,29 @@
+variable "rds" {
+  type = map(string)
+
+  default = {
+    "default.name"           = "prod-database"
+    "stg.name"               = "stg-database"
+    "dev.name"               = "dev-database"
+    "default.engine"         = "aurora-mysql"
+    "default.engine_version" = "5.7.mysql_aurora.2.09.2"
+    "default.instance_class" = "db.t3.small"
+    "default.instance_count" = 1
+  }
+}
+
+variable "rds_local_writer_domain_name" {
+  type    = string
+  default = "rds-writer"
+}
+
+variable "rds_local_reader_domain_name" {
+  type    = string
+  default = "rds-reader"
+}
+
+variable "vpc" {
+  type = map(string)
+
+  default = {}
+}

--- a/modules/aws/rds/variable.tf
+++ b/modules/aws/rds/variable.tf
@@ -22,6 +22,20 @@ variable "rds_local_reader_domain_name" {
   default = "rds-reader"
 }
 
+variable "bastion" {
+  type = map(string)
+
+  default = {
+    "default.name"          = "prod-bastion"
+    "stg.name"              = "stg-bastion"
+    "dev.name"              = "dev-bastion"
+    "default.ami"           = "ami-0ca38c7440de1749a"
+    "default.instance_type" = "t2.micro"
+    "default.volume_type"   = "gp2"
+    "default.volume_size"   = "30"
+  }
+}
+
 variable "vpc" {
   type = map(string)
 

--- a/modules/aws/rds/variable.tf
+++ b/modules/aws/rds/variable.tf
@@ -8,7 +8,7 @@ variable "rds" {
     "default.engine"         = "aurora-mysql"
     "default.engine_version" = "5.7.mysql_aurora.2.09.2"
     "default.instance_class" = "db.t3.small"
-    "default.instance_count" = 1
+    "default.instance_count" = 2
   }
 }
 

--- a/modules/aws/vpc/output.tf
+++ b/modules/aws/vpc/output.tf
@@ -1,9 +1,10 @@
+// NAT Gatewayは料金が高いので必要な時だけ作成する
 output "vpc" {
   value = {
-    "vpc_id"           = aws_vpc.vpc.id
-    "nat_ip_1"         = aws_eip.nat_ip_1.public_ip
-    "nat_ip_2"         = aws_eip.nat_ip_2.public_ip
-    "nat_ip_3"         = aws_eip.nat_ip_3.public_ip
+    "vpc_id" = aws_vpc.vpc.id
+    //    "nat_ip_1"         = aws_eip.nat_ip_1.public_ip
+    //    "nat_ip_2"         = aws_eip.nat_ip_2.public_ip
+    //    "nat_ip_3"         = aws_eip.nat_ip_3.public_ip
     "subnet_public_1"  = aws_subnet.public_1.id
     "subnet_public_2"  = aws_subnet.public_2.id
     "subnet_public_3"  = aws_subnet.public_3.id

--- a/modules/aws/vpc/private-route.tf
+++ b/modules/aws/vpc/private-route.tf
@@ -1,98 +1,100 @@
-resource "aws_eip" "nat_ip_1" {
-  tags = {
-    Name = "${terraform.workspace}-nat-ip-1"
-  }
-}
+// NAT Gatewayは料金が高いので必要な時だけ作成する
 
-resource "aws_eip" "nat_ip_2" {
-  tags = {
-    Name = "${terraform.workspace}-nat-ip-2"
-  }
-}
-
-resource "aws_eip" "nat_ip_3" {
-  tags = {
-    Name = "${terraform.workspace}-nat-ip-3"
-  }
-}
-
-resource "aws_nat_gateway" "nat_1" {
-  allocation_id = aws_eip.nat_ip_1.id
-  subnet_id     = aws_subnet.public_1.id
-
-  tags = {
-    Name = "${terraform.workspace}-1"
-  }
-}
-
-resource "aws_nat_gateway" "nat_2" {
-  allocation_id = aws_eip.nat_ip_2.id
-  subnet_id     = aws_subnet.public_2.id
-
-  tags = {
-    Name = "${terraform.workspace}-2"
-  }
-}
-
-resource "aws_nat_gateway" "nat_3" {
-  allocation_id = aws_eip.nat_ip_3.id
-  subnet_id     = aws_subnet.public_3.id
-
-  tags = {
-    Name = "${terraform.workspace}-3"
-  }
-}
-
-resource "aws_route_table" "private_1" {
-  vpc_id = aws_vpc.vpc.id
-
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_1.id
-  }
-
-  tags = {
-    Name = "${terraform.workspace}-private-rt-1"
-  }
-}
-
-resource "aws_route_table" "private_2" {
-  vpc_id = aws_vpc.vpc.id
-
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_2.id
-  }
-
-  tags = {
-    Name = "${terraform.workspace}-private-rt-2"
-  }
-}
-
-resource "aws_route_table" "private_3" {
-  vpc_id = aws_vpc.vpc.id
-
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_3.id
-  }
-
-  tags = {
-    Name = "${terraform.workspace}-private-rt-3"
-  }
-}
-
-resource "aws_route_table_association" "private_1" {
-  route_table_id = aws_route_table.private_1.id
-  subnet_id      = aws_subnet.private_1.id
-}
-
-resource "aws_route_table_association" "private_app_2" {
-  route_table_id = aws_route_table.private_2.id
-  subnet_id      = aws_subnet.private_2.id
-}
-
-resource "aws_route_table_association" "private_app_3" {
-  route_table_id = aws_route_table.private_3.id
-  subnet_id      = aws_subnet.private_3.id
-}
+//resource "aws_eip" "nat_ip_1" {
+//  tags = {
+//    Name = "${terraform.workspace}-nat-ip-1"
+//  }
+//}
+//
+//resource "aws_eip" "nat_ip_2" {
+//  tags = {
+//    Name = "${terraform.workspace}-nat-ip-2"
+//  }
+//}
+//
+//resource "aws_eip" "nat_ip_3" {
+//  tags = {
+//    Name = "${terraform.workspace}-nat-ip-3"
+//  }
+//}
+//
+//resource "aws_nat_gateway" "nat_1" {
+//  allocation_id = aws_eip.nat_ip_1.id
+//  subnet_id     = aws_subnet.public_1.id
+//
+//  tags = {
+//    Name = "${terraform.workspace}-1"
+//  }
+//}
+//
+//resource "aws_nat_gateway" "nat_2" {
+//  allocation_id = aws_eip.nat_ip_2.id
+//  subnet_id     = aws_subnet.public_2.id
+//
+//  tags = {
+//    Name = "${terraform.workspace}-2"
+//  }
+//}
+//
+//resource "aws_nat_gateway" "nat_3" {
+//  allocation_id = aws_eip.nat_ip_3.id
+//  subnet_id     = aws_subnet.public_3.id
+//
+//  tags = {
+//    Name = "${terraform.workspace}-3"
+//  }
+//}
+//
+//resource "aws_route_table" "private_1" {
+//  vpc_id = aws_vpc.vpc.id
+//
+//  route {
+//    cidr_block     = "0.0.0.0/0"
+//    nat_gateway_id = aws_nat_gateway.nat_1.id
+//  }
+//
+//  tags = {
+//    Name = "${terraform.workspace}-private-rt-1"
+//  }
+//}
+//
+//resource "aws_route_table" "private_2" {
+//  vpc_id = aws_vpc.vpc.id
+//
+//  route {
+//    cidr_block     = "0.0.0.0/0"
+//    nat_gateway_id = aws_nat_gateway.nat_2.id
+//  }
+//
+//  tags = {
+//    Name = "${terraform.workspace}-private-rt-2"
+//  }
+//}
+//
+//resource "aws_route_table" "private_3" {
+//  vpc_id = aws_vpc.vpc.id
+//
+//  route {
+//    cidr_block     = "0.0.0.0/0"
+//    nat_gateway_id = aws_nat_gateway.nat_3.id
+//  }
+//
+//  tags = {
+//    Name = "${terraform.workspace}-private-rt-3"
+//  }
+//}
+//
+//resource "aws_route_table_association" "private_1" {
+//  route_table_id = aws_route_table.private_1.id
+//  subnet_id      = aws_subnet.private_1.id
+//}
+//
+//resource "aws_route_table_association" "private_app_2" {
+//  route_table_id = aws_route_table.private_2.id
+//  subnet_id      = aws_subnet.private_2.id
+//}
+//
+//resource "aws_route_table_association" "private_app_3" {
+//  route_table_id = aws_route_table.private_3.id
+//  subnet_id      = aws_subnet.private_3.id
+//}

--- a/providers/aws/environments/10-network/main.tf
+++ b/providers/aws/environments/10-network/main.tf
@@ -3,11 +3,12 @@ module "vpc" {
   availability_zone = var.default_az
 }
 
-module "vpc_us_east_1" {
-  source            = "../../../../modules/aws/vpc"
-  availability_zone = var.us_east_1_az
-
-  providers = {
-    aws = aws.us_east_1
-  }
-}
+// マルチリージョンは料金が高いので普段はコメントアウト、検証が必要な時だけコメントアウトを解除する
+//module "vpc_us_east_1" {
+//  source            = "../../../../modules/aws/vpc"
+//  availability_zone = var.us_east_1_az
+//
+//  providers = {
+//    aws = aws.us_east_1
+//  }
+//}

--- a/providers/aws/environments/10-network/output.tf
+++ b/providers/aws/environments/10-network/output.tf
@@ -2,6 +2,7 @@ output "vpc" {
   value = module.vpc.vpc
 }
 
-output "vpc_us_east_1" {
-  value = module.vpc_us_east_1.vpc
-}
+// マルチリージョンは料金が高いので普段はコメントアウト、検証が必要な時だけコメントアウトを解除する
+//output "vpc_us_east_1" {
+//  value = module.vpc_us_east_1.vpc
+//}

--- a/providers/aws/environments/10-network/provider.tf
+++ b/providers/aws/environments/10-network/provider.tf
@@ -3,8 +3,9 @@ provider "aws" {
   profile = "nekochans-dev"
 }
 
-provider "aws" {
-  region  = "us-east-1"
-  profile = "nekochans-dev"
-  alias   = "us_east_1"
-}
+// マルチリージョンは料金が高いので普段はコメントアウト、検証が必要な時だけコメントアウトを解除する
+//provider "aws" {
+//  region  = "us-east-1"
+//  profile = "nekochans-dev"
+//  alias   = "us_east_1"
+//}

--- a/providers/aws/environments/10-network/variable.tf
+++ b/providers/aws/environments/10-network/variable.tf
@@ -8,12 +8,13 @@ variable "default_az" {
   }
 }
 
-variable "us_east_1_az" {
-  type = map(string)
-
-  default = {
-    "default.az_1" = "us-east-1a"
-    "default.az_2" = "us-east-1b"
-    "default.az_3" = "us-east-1b"
-  }
-}
+// マルチリージョンは料金が高いので普段はコメントアウト、検証が必要な時だけコメントアウトを解除する
+//variable "us_east_1_az" {
+//  type = map(string)
+//
+//  default = {
+//    "default.az_1" = "us-east-1a"
+//    "default.az_2" = "us-east-1b"
+//    "default.az_3" = "us-east-1b"
+//  }
+//}

--- a/providers/aws/environments/14-rds/.terraform.lock.hcl
+++ b/providers/aws/environments/14-rds/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.28.0"
+  constraints = "3.28.0"
+  hashes = [
+    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+  ]
+}

--- a/providers/aws/environments/14-rds/.terraform.lock.hcl
+++ b/providers/aws/environments/14-rds/.terraform.lock.hcl
@@ -2,19 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.28.0"
-  constraints = "3.28.0"
+  version     = "3.39.0"
+  constraints = "3.39.0"
   hashes = [
-    "h1:zejsAukFmgZCOdQCk44L3cumXFs8YDSltRIjZN+izsU=",
-    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
-    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
-    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
-    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
-    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
-    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
-    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
-    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
-    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
-    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
+    "h1:goOMfGE4SjLps+hpxJFEM/pZFiNgvi6BMG8/w86+f6k=",
+    "zh:2014b397dd93fa55f2f2d1338c19e5b2b77b025a76a6b1fceea0b8696e984b9c",
+    "zh:23d59c68ab50148a0f5c911a801734e9934a1fccd41118a8efb5194135cbd360",
+    "zh:412eab41d4934ca9c47083faa128e4cd585c3bb44ad718e40d67091aebc02f4e",
+    "zh:4b75e0a259b56d97e66b7d69f3f25bd4cc7be2440c0fe35529f46de7d40a49d3",
+    "zh:694a32519dcca5bd8605d06481d16883d55160d97c1f4039deb13c6ca8de8427",
+    "zh:6a0bcef43c2d9a97aeaaac3c5d1d6728dc2464a51a014f118c691c79029d0903",
+    "zh:6d78fc7c663247ca2a80f276008dcdafece4cac75e2639bbce188c08b796040a",
+    "zh:78f846a505d7b64b67feed1527d4d2b40130dadaf8e3112113685e148f49b156",
+    "zh:881bc969432d3ef6ec70f5a762c3415e037904338579b0a360c6818b74d26e59",
+    "zh:96c1ca80c1d693a3eef80489adb45c076ee8e6878e461d6c29b05388d4b95f48",
+    "zh:9be5fa342272586fc6e319e20f21c0c5c801b05dcf7d59e473ad0882c9ecfa70",
   ]
 }

--- a/providers/aws/environments/14-rds/backend.tf
+++ b/providers/aws/environments/14-rds/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "keitakn-tfstate"
+    key     = "rds/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "nekochans-dev"
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "keitakn-tfstate"
+    key     = "env:/${terraform.workspace}/network/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "nekochans-dev"
+  }
+}

--- a/providers/aws/environments/14-rds/main.tf
+++ b/providers/aws/environments/14-rds/main.tf
@@ -1,0 +1,4 @@
+module "api" {
+  source = "../../../../modules/aws/rds"
+  vpc    = data.terraform_remote_state.network.outputs.vpc
+}

--- a/providers/aws/environments/14-rds/provider.tf
+++ b/providers/aws/environments/14-rds/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "nekochans-dev"
+}

--- a/providers/aws/environments/14-rds/versions.tf
+++ b/providers/aws/environments/14-rds/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.28.0"
+    }
+  }
+}

--- a/providers/aws/environments/14-rds/versions.tf
+++ b/providers/aws/environments/14-rds/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.28.0"
+      version = "3.39.0"
     }
   }
 }

--- a/terraform-init-dev.sh
+++ b/terraform-init-dev.sh
@@ -9,6 +9,7 @@ tfstateDirList='
 /app/my-terraform/providers/aws/environments/11-cognito
 /app/my-terraform/providers/aws/environments/12-dynamodb
 /app/my-terraform/providers/aws/environments/13-lambda
+/app/my-terraform/providers/aws/environments/14-rds
 /app/my-terraform/providers/aws/environments/20-api
 /app/my-terraform/providers/aws/environments/20-eks
 '


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/my-terraform/issues/51

# Doneの定義
- RDS Proxyが作成され接続出来る状態になっている事

# スクリーンショット

正常に作成されている事を確認。

![RDSProxy1](https://user-images.githubusercontent.com/11032365/117911534-ed7e5a80-b318-11eb-9fe8-35e863fc0e38.png)

# 変更点概要
- RDSCluster（MySQL互換のAmazon Aurora MySQLを利用）の作成
- RDS Proxyの作成
- RDS Proxyに接続確認する為のEC2インスタンスを作成

NAT Gatewayが結構高いので、RDSに利用するサブネットはパブリックサブネットにしてある。

これによりNAT Gatewayの作成を行わなくても良い状態にしてある。

# 補足情報
作業時の手順は以下にメモしてある。

https://zenn.dev/keitakn/scraps/45126a3cf404ab

これを元にして次はAWS Lambdaから接続出来るサンプルを作る。