### PR TITLE
RDSのMigrationを実行する為に必要なリソースを追加

### DIFF
--- a/modules/aws/rds/codebuild.tf
+++ b/modules/aws/rds/codebuild.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "serverless_node_api_migration" {
   }
 }
 
-resource "aws_codebuild_project" "serverless_node_api_migration" {
+resource "aws_codebuild_project" "serverless_node_api_migrate_up" {
   artifacts {
     type = "NO_ARTIFACTS"
   }
@@ -46,14 +46,72 @@ resource "aws_codebuild_project" "serverless_node_api_migration" {
     }
   }
 
-  name         = "${terraform.workspace}-serverless-node-api-rds-migration"
+  name         = "${terraform.workspace}-serverless-node-api-rds-migrate-up"
   service_role = aws_iam_role.rds_migration_role.arn
 
   source {
     type            = "GITHUB"
     location        = "https://github.com/nekochans/aws-serverless-node-api-boilerplate.git"
     git_clone_depth = 1
-    buildspec       = "buildspec.yml"
+    buildspec       = "buildspec-migrate-up.yml"
+  }
+
+  vpc_config {
+    security_group_ids = [aws_security_group.serverless_node_api_migration.id]
+
+    subnets = [
+      var.vpc["subnet_private_1"],
+      var.vpc["subnet_private_2"],
+      var.vpc["subnet_private_3"],
+    ]
+
+    vpc_id = var.vpc["vpc_id"]
+  }
+}
+
+resource "aws_codebuild_project" "serverless_node_api_migrate_down" {
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/standard:5.0"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable {
+      name  = "DB_USERNAME"
+      value = aws_ssm_parameter.serverless_node_api_db_user.name
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_PASSWORD"
+      value = aws_ssm_parameter.serverless_node_api_db_password.name
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_HOST"
+      value = "${aws_route53_record.rds_local_writer_domain_record.name}.${aws_route53_zone.rds_local_domain_name.name}"
+      type  = "PLAINTEXT"
+    }
+
+    environment_variable {
+      name  = "DB_NAME"
+      value = "serverless_db"
+      type  = "PLAINTEXT"
+    }
+  }
+
+  name         = "${terraform.workspace}-serverless-node-api-rds-migrate-down"
+  service_role = aws_iam_role.rds_migration_role.arn
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/nekochans/aws-serverless-node-api-boilerplate.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec-migrate-down.yml"
   }
 
   vpc_config {

--- a/modules/aws/rds/codebuild.tf
+++ b/modules/aws/rds/codebuild.tf
@@ -1,0 +1,70 @@
+resource "aws_security_group" "serverless_node_api_migration" {
+  name        = "${terraform.workspace}-serverless-node-api-migration"
+  description = "aws-serverless-node-api-boilerplate execute RDS Migration"
+  vpc_id      = var.vpc["vpc_id"]
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_codebuild_project" "serverless_node_api_migration" {
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/standard:5.0"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable {
+      name  = "DB_USERNAME"
+      value = aws_ssm_parameter.serverless_node_api_db_user.name
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_PASSWORD"
+      value = aws_ssm_parameter.serverless_node_api_db_password.name
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_HOST"
+      value = "${aws_route53_record.rds_local_writer_domain_record.name}.${aws_route53_zone.rds_local_domain_name.name}"
+      type  = "PLAINTEXT"
+    }
+
+    environment_variable {
+      name  = "DB_NAME"
+      value = "serverless_db"
+      type  = "PLAINTEXT"
+    }
+  }
+
+  name         = "${terraform.workspace}-serverless-node-api-rds-migration"
+  service_role = aws_iam_role.rds_migration_role.arn
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/nekochans/aws-serverless-node-api-boilerplate.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec.yml"
+  }
+
+  vpc_config {
+    security_group_ids = [aws_security_group.serverless_node_api_migration.id]
+
+    subnets = [
+      var.vpc["subnet_private_1"],
+      var.vpc["subnet_private_2"],
+      var.vpc["subnet_private_3"],
+    ]
+
+    vpc_id = var.vpc["vpc_id"]
+  }
+}

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -34,6 +34,15 @@ resource "aws_security_group_rule" "rds_from_rds_proxy" {
   depends_on               = [aws_security_group.rds_proxy]
 }
 
+resource "aws_security_group_rule" "rds_from_serverless_node_api_migration" {
+  security_group_id        = aws_security_group.rds_cluster.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.serverless_node_api_migration.id
+}
+
 resource "aws_db_subnet_group" "rds_subnet_group" {
   name        = lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])
   description = "${lookup(var.rds, "${terraform.workspace}.name", var.rds["default.name"])}-subnet-group"

--- a/modules/aws/rds/parameterstore.tf
+++ b/modules/aws/rds/parameterstore.tf
@@ -1,0 +1,13 @@
+resource "aws_ssm_parameter" "serverless_node_api_db_user" {
+  name      = "/${terraform.workspace}/aws-serverless-node-api-boilerplate/DB_USERNAME"
+  type      = "SecureString"
+  value     = aws_rds_cluster.rds_cluster.master_username
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "serverless_node_api_db_password" {
+  name      = "/${terraform.workspace}/aws-serverless-node-api-boilerplate/DB_PASSWORD"
+  type      = "SecureString"
+  value     = aws_rds_cluster.rds_cluster.master_password
+  overwrite = true
+}

--- a/modules/aws/vpc/nat-instance.tf
+++ b/modules/aws/vpc/nat-instance.tf
@@ -1,0 +1,170 @@
+resource "aws_security_group" "nat_instance" {
+  name = lookup(
+    var.nat_instance,
+    "${terraform.workspace}.name",
+    var.nat_instance["default.name"],
+  )
+  description = lookup(
+    var.nat_instance,
+    "${terraform.workspace}.name",
+    var.nat_instance["default.name"],
+  )
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = lookup(
+      var.nat_instance,
+      "${terraform.workspace}.name",
+      var.nat_instance["default.name"],
+    )
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "http_from_vpc_to_nat_instance" {
+  security_group_id = aws_security_group.nat_instance.id
+  type              = "ingress"
+  from_port         = "80"
+  to_port           = "80"
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.vpc.cidr_block]
+}
+
+resource "aws_security_group_rule" "https_from_vpc_to_nat_instance" {
+  security_group_id = aws_security_group.nat_instance.id
+  type              = "ingress"
+  from_port         = "443"
+  to_port           = "443"
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.vpc.cidr_block]
+}
+
+data "aws_iam_policy_document" "nat_instance_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "nat_instance_role" {
+  name               = "${terraform.workspace}-nat-instance-default-role"
+  assume_role_policy = data.aws_iam_policy_document.nat_instance_trust_relationship.json
+}
+
+resource "aws_iam_role_policy_attachment" "attachment_amazon_ec2_role_for_ssm" {
+  role       = aws_iam_role.nat_instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "nat_instance_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:PutMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+      "ec2:DescribeTags",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "nat_instance_role_policy" {
+  name   = "${terraform.workspace}-nat-instance-role-policy"
+  role   = aws_iam_role.nat_instance_role.id
+  policy = data.aws_iam_policy_document.nat_instance_policy.json
+}
+
+resource "aws_iam_instance_profile" "nat_instance_profile" {
+  name = "${terraform.workspace}-nat-instance-profile"
+  role = aws_iam_role.nat_instance_role.name
+}
+
+resource "aws_instance" "nat_instance" {
+  ami = lookup(
+    var.nat_instance,
+    "${terraform.workspace}.ami",
+    var.nat_instance["default.ami"],
+  )
+  associate_public_ip_address = true
+  instance_type = lookup(
+    var.nat_instance,
+    "${terraform.workspace}.instance_type",
+    var.nat_instance["default.instance_type"],
+  )
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = lookup(
+      var.nat_instance,
+      "${terraform.workspace}.volume_type",
+      var.nat_instance["default.volume_type"],
+    )
+    volume_size = lookup(
+      var.nat_instance,
+      "${terraform.workspace}.volume_size",
+      var.nat_instance["default.volume_size"],
+    )
+  }
+
+  subnet_id              = aws_subnet.public_3.id
+  vpc_security_group_ids = [aws_security_group.nat_instance.id]
+
+  tags = {
+    "Name" = "${terraform.workspace}-nat-instance-3"
+  }
+
+  iam_instance_profile = aws_iam_instance_profile.nat_instance_profile.name
+  monitoring           = true
+  source_dest_check    = false
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "aws_route_table" "nat_instance_private" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block  = "0.0.0.0/0"
+    instance_id = aws_instance.nat_instance.id
+  }
+
+  tags = {
+    Name = "${lookup(
+      var.nat_instance,
+      "${terraform.workspace}.name",
+      var.nat_instance["default.name"],
+    )}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "nat_instance_private_1" {
+  route_table_id = aws_route_table.nat_instance_private.id
+  subnet_id      = aws_subnet.private_1.id
+}
+
+resource "aws_route_table_association" "nat_instance_private_2" {
+  route_table_id = aws_route_table.nat_instance_private.id
+  subnet_id      = aws_subnet.private_2.id
+}
+
+resource "aws_route_table_association" "nat_instance_private_3" {
+  route_table_id = aws_route_table.nat_instance_private.id
+  subnet_id      = aws_subnet.private_3.id
+}

--- a/modules/aws/vpc/variable.tf
+++ b/modules/aws/vpc/variable.tf
@@ -40,3 +40,17 @@ variable "availability_zone" {
   type    = map(string)
   default = {}
 }
+
+variable "nat_instance" {
+  type = map(string)
+
+  default = {
+    "default.name"          = "prod-nat-instance"
+    "stg.name"              = "stg-nat-instance"
+    "dev.name"              = "dev-nat-instance"
+    "default.ami"           = "ami-00d29e4cb217ae06b"
+    "default.instance_type" = "t2.micro"
+    "default.volume_type"   = "gp2"
+    "default.volume_size"   = "30"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/my-terraform/issues/54

# Doneの定義
- https://github.com/nekochans/aws-serverless-node-api-boilerplate/pull/34 のMigrationが実行出来る状態になっている事

# 変更点概要

RDSのMigrationを実行する為のCodeBuildプロジェクトを作成。

NATGatewayが高いので、最初はCodeBuildをpublicサブネットに配置する事でRDSへの接続を行うCodeBuildプロジェクトを作成しようと思ったが、VPC内のCodeBuildはパブリックIPを持たない為、GitHubからソースをダウンロード出来ずに、Migrationが実行出来なかったので、NATインスタンスを作成する事で対応した。

https://funasaki.hatenablog.com/entry/2018/02/22/153601

実際に運用する際はNATGatewayを使ったほうが良いと思う。